### PR TITLE
ci(jenkins): support test containers in the CI

### DIFF
--- a/.ci/docker/sdk-linux/Dockerfile
+++ b/.ci/docker/sdk-linux/Dockerfile
@@ -11,3 +11,14 @@ RUN /bin/bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version 2.1.50
 
 # Install dotnet-xunit-to-junit
 RUN dotnet tool install --tool-path /usr/share/dotnet/tools dotnet-xunit-to-junit --version 0.3.1
+
+# Install docker
+RUN apt update \
+ && apt-get -qq install -y apt-transport-https ca-certificates curl \
+    gnupg2 software-properties-common --no-install-recommends \
+ && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+ && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+ && apt -qq update \
+ && apt-get -qq install -y docker-ce docker-ce-cli containerd.io \
+    --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*

--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -3,6 +3,7 @@
 ::
 dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
 dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
-dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj 
+dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
+dotnet sln remove test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
 
 dotnet build --verbosity detailed

--- a/.ci/windows/prepare-test.bat
+++ b/.ci/windows/prepare-test.bat
@@ -4,3 +4,4 @@
 dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
 dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
 dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
+dotnet sln remove test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -426,7 +426,7 @@ def cleanDir(path){
 def dotnet(Closure body){
   def dockerTagName = 'docker.elastic.co/observability-ci/apm-agent-dotnet-sdk-linux:latest'
   sh label: 'Docker build', script: "docker build --tag ${dockerTagName} .ci/docker/sdk-linux"
-  docker.image("${dockerTagName}").inside("-e HOME='${env.WORKSPACE}/${env.BASE_DIR}'"){
+  docker.image("${dockerTagName}").inside("-e HOME='${env.WORKSPACE}/${env.BASE_DIR}' -v /var/run/docker.sock:/var/run/docker.sock"){
     body()
   }
 }

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientDiagnosticListenerTests.cs
@@ -26,8 +26,9 @@ namespace Elastic.Apm.SqlClient.Tests
 
 		public SqlClientDiagnosticListenerTests()
 		{
+			// BUILD_ID env variable is passed from the CI, therefore DockerInDocker is enabled.
 			_environment = new DockerEnvironmentBuilder()
-				.DockerInDocker(true)
+				.DockerInDocker(Environment.GetEnvironmentVariable("BUILD_ID") != null)
 				.AddMssqlContainer(ContainerName, "StrongPassword!!!!1")
 				.Build();
 

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientDiagnosticListenerTests.cs
@@ -27,6 +27,7 @@ namespace Elastic.Apm.SqlClient.Tests
 		public SqlClientDiagnosticListenerTests()
 		{
 			_environment = new DockerEnvironmentBuilder()
+				.DockerInDocker(true)
 				.AddMssqlContainer(ContainerName, "StrongPassword!!!!1")
 				.Build();
 


### PR DESCRIPTION
This is regarding the PR https://github.com/elastic/apm-agent-dotnet/pull/592 and to honor the CI with its implementation.

## Tasks
- [x] Exposing the host docker socket inside the container.
- [x] Run DinD only if running in the CI  
- [x] Run only the tests in Linux. Windows is not yet supported. 

## Tests
- Test execution output in the CI

![image](https://user-images.githubusercontent.com/2871786/71971753-3133f200-3203-11ea-881d-04d1b0b9ccb4.png)

![image](https://user-images.githubusercontent.com/2871786/71971810-4b6dd000-3203-11ea-846e-f075c2005bc8.png)

## How to test this locally

```bash
docker build --tag sdk-linux-docker .ci/docker/sdk-linux 

docker run --rm -ti \ 
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(pwd):/app \
   -w /app/test/Elastic.Apm.SqlClient.Tests \
   -e BUILD_ID=1 \
   sdk-linux-docker \
   dotnet test
```


## CI tests

https://github.com/elastic/apm-agent-dotnet/pull/678 was created for testing purposes.